### PR TITLE
fixed single line comment symbol

### DIFF
--- a/puppet.configuration.json
+++ b/puppet.configuration.json
@@ -1,7 +1,7 @@
 {
 	"comments": {
 		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
+		"lineComment": "#",
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
 		"blockComment": [ "/*", "*/" ]
 	},


### PR DESCRIPTION
simple change so the single line comment is correct for puppet.
Changed from `//` to `#`
