### PR TITLE
Fixed calling of puppet-lint on windows.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - node
+script: 'true'

--- a/src/features/puppetLintProvider.ts
+++ b/src/features/puppetLintProvider.ts
@@ -21,7 +21,18 @@ export default class PuppetLintProvider {
 
         let options = vscode.workspace.rootPath ? { cwd: vscode.workspace.rootPath } : undefined;
 
-        let childProcess = cp.spawn('puppet-lint', ["--log-format", "%{KIND}:%{line}:%{message}", textDocument.fileName], options);
+        let command = '';
+        let commandOptions = ["--log-format", "%{KIND}:%{line}:%{message}", textDocument.fileName];
+
+        if (process.platform == "win32") {
+            command = "cmd.exe";
+            commandOptions = ["/c", "puppet-lint"].concat(commandOptions);
+        }
+        else {
+            command = "puppet-lint";
+        }
+        commandOptions.concat
+        let childProcess = cp.spawn(command, commandOptions, options);
         if (childProcess.pid) {
             childProcess.stdout.on('data', (data: Buffer) => {
                 decoded += data;


### PR DESCRIPTION
Checking the code with `puppet-lint`does not work on windows, because the spawning process needs to be wrapped by a windows `cmd`-call: `cmd /c <call as it would be on Linux/MacOS>`.

Fixes #12.