### PR TITLE
- Added Puppet Parser Validate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,23 @@
 # Puppet Extension for Visual Studio Code, now with Linter
 
-The Puppet Extension for Visual Studio Code offers rich language support for Puppet DSL, snippets, and linter when using [Visual Studio Code](http://code.visualstudio.com).
+The Puppet Extension for Visual Studio Code offers rich language support for Puppet DSL, snippets, linter and parser support when using [Visual Studio Code](http://code.visualstudio.com).
 
 ## Requirements
+
 puppet-lint ruby gem http://puppet-lint.com/
 
 ```
-sudo gem install puppet-lint
+gem install puppet-lint
 ```
 
 ## Features
 
 ### Syntax Keywords
+
 - Puppet DSL Syntax
 
 ### Snippets
+
 - augeas
 - case
 - cron
@@ -39,6 +42,7 @@ sudo gem install puppet-lint
 - zpool
 
 ### Disable Checks
+
 To disable various checks, create a `~/.puppet-lint.rc` file. Add switches, one per line. For full list of switches run `puppet-lint --help`
 
 ```
@@ -51,12 +55,16 @@ To disable various checks, create a `~/.puppet-lint.rc` file. Add switches, one 
 Contributions are welcomed, please file issues and pull requests via the [project homepage](https://github.com/blindly/vscode-puppet).
 
 ### Thanks to contributors
+
 - [blindly](https://github.com/blindly)
 - [jgreat](https://github.com/jgreat)
 - [dhollinger](https://github.com/dhollinger)
 - [mikemimik](https://github.com/mikemimik)
+- [pjmagee](https://github.com/pjmagee)
 
 ## Changelog
+
 - 0.2.0 - Added MIT License
 - 0.3.0 - Merged with [Puppet Linter Extension](https://github.com/jgreat/vscode-puppetlinter)
 - 0.3.1 - Removed old Puppet file detection documentation
+- 0.4.0 - Added Puppet Parser Validate support

--- a/package.json
+++ b/package.json
@@ -1,53 +1,73 @@
 {
-  "name": "puppet",
-  "description": "Puppet language support, snippets and linter for Visual Studio Code",
-  "version": "0.3.1",
-  "publisher": "Borke",
-  "license": "MIT",
-  "keywords": [
-    "puppet",
-    "puppet-lint"
-  ],
-  "icon": "puppet.png",
-  "engines": {
-    "vscode": "^1.0.0"
-  },
-  "categories": [
-    "Linters",
-    "Languages",
-    "Snippets"
-  ],
-  "main": "./out/src/extension",
-  "contributes": {
-    "languages": [{
-      "id": "puppet",
-      "aliases": ["Puppet", "puppet"],
-      "extensions": [".pp", ".epp"],
-      "configuration": "./puppet.configuration.json"
-    }],
-    "grammars": [{
-      "language": "puppet",
-      "scopeName": "source.puppet",
-      "path": "./syntaxes/puppet.tmLanguage"
-    }],
-    "snippets": [{
-      "language": "puppet",
-      "path": "./snippets/snippets.json"
-    }]
-  },
-  "activationEvents": [
-    "onLanguage:puppet"
-  ],
-  "scripts": {
-    "vscode:prepublish": "node_modules/typescript/bin/tsc -p ./",
-    "compile": "node_modules/typescript/bin/tsc -watch -p ./",
-    "postinstall": "node ./node_modules/vscode/bin/install"
-  },
-  "devDependencies": {
-    "typescript": "^2.0.3",
-    "vscode": "^1.0.0",
-    "mocha": "^2.3.3",
-    "@types/node": "^6.0.40",
-    "@types/mocha": "^2.2.32"
-  }
+    "name": "puppet",
+    "description": "Puppet language support, snippets and linter for Visual Studio Code",
+    "version": "0.3.1",
+    "publisher": "Borke",
+    "license": "MIT",
+    "keywords": [
+        "puppet",
+        "puppet-lint"
+    ],
+    "icon": "puppet.png",
+    "engines": {
+        "vscode": "^1.0.0"
+    },
+    "categories": [
+        "Linters",
+        "Languages",
+        "Snippets"
+    ],
+    "main": "./out/src/extension",
+    "contributes": {
+        "languages": [{
+            "id": "puppet",
+            "aliases": ["Puppet", "puppet"],
+            "extensions": [".pp", ".epp"],
+            "configuration": "./puppet.configuration.json"
+        }],
+        "grammars": [{
+            "language": "puppet",
+            "scopeName": "source.puppet",
+            "path": "./syntaxes/puppet.tmLanguage.json"
+        }],
+        "snippets": [{
+            "language": "puppet",
+            "path": "./snippets/snippets.json"
+        }],
+        "configuration": {
+            "title": "puppet",
+            "properties": {
+                "puppet": {
+                    "properties": {
+                        "lint": {
+                            "type": "string",
+                            "default": "puppet-lint.bat",
+                            "description": "Path to the Puppet linter. (e.g ruby bin)."
+                        },
+                        "puppet": {
+                            "type": "string",
+                            "default": "puppet.bat",
+                            "description": "Path to the Puppet executable. (e.g C:\\Program Files\\Puppet Labs\\Puppet\\bin)"
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "activationEvents": [
+        "onLanguage:puppet"
+    ],
+    "scripts": {
+        "vscode:prepublish": "tsc -p ./",
+        "compile": "tsc -watch -p ./",
+        "postinstall": "node ./node_modules/vscode/bin/install"
+    },
+    "devDependencies": {
+        "typescript": "^2.0.3",
+        "tslint": "^5.1.0",
+        "vscode": "^1.0.0",
+        "mocha": "^2.3.3",
+        "@types/node": "^6.0.40",
+        "@types/mocha": "^2.2.32"
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,13 @@
-import * as vscode from 'vscode'; 
+import * as vscode from "vscode";
 
-import PuppetLintProvider from './features/puppetLintProvider';
+import PuppetLintProvider from "./features/puppetLintProvider";
+import PuppetParserProvider from "./features/puppetParserProvider";
 
 export function activate(context: vscode.ExtensionContext) {
-    let linter = new PuppetLintProvider();  
+
+    let linter = new PuppetLintProvider();
     linter.activate(context.subscriptions);
-    //vscode.languages.registerCodeActionsProvider('puppet', linter);
+
+    let parser = new PuppetParserProvider();
+    parser.activate(context.subscriptions);
 }

--- a/src/features/puppetLintProvider.ts
+++ b/src/features/puppetLintProvider.ts
@@ -1,42 +1,46 @@
 // src/features/puppetLintProvider.ts
-'use strict';
+"use strict";
+import * as cp from "child_process";
 
-import * as path from 'path';
-import * as cp from 'child_process';
-import ChildProcess = cp.ChildProcess;
-
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
 export default class PuppetLintProvider {
 
     private diagnosticCollection: vscode.DiagnosticCollection;
 
     private doPuppetLint(textDocument: vscode.TextDocument) {
-        if (textDocument.languageId !== 'puppet') {
+        if (textDocument.languageId !== "puppet") {
             return;
         }
 
-        let decoded = ''
+        let decoded: string = '';
         let diagnostics: vscode.Diagnostic[] = [];
 
         let options = vscode.workspace.rootPath ? { cwd: vscode.workspace.rootPath } : undefined;
 
-        let childProcess = cp.spawn('puppet-lint', ["--log-format", "%{KIND}:%{line}:%{message}", textDocument.fileName], options);
+        const config = vscode.workspace.getConfiguration('puppet');
+        let path = config.get<string>('lint');
+
+        if (path.indexOf(' ') > -1) {
+            path = `"${path}"`;
+        }
+
+        let childProcess = cp.spawn(path, ["--log-format", "%{KIND}:%{line}:%{message}", textDocument.fileName], options);
         if (childProcess.pid) {
             childProcess.stdout.on('data', (data: Buffer) => {
                 decoded += data;
             });
             childProcess.stdout.on('end', () => {
-                decoded.split("\n").forEach( item => {
+                decoded.split("\n").forEach(item => {
                     if (item) {
                         let error = item.split(":");
                         let severity = error[0].toLowerCase() === "warning" ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error;
                         let message = "puppet-lint: " + error[0] + ": " + error[2];
-                        let range = new vscode.Range(Number(error[1]) - 1, 0, Number(error[1]) -1, 300);
+                        let range = new vscode.Range(Number(error[1]) - 1, 0, Number(error[1]) - 1, 300);
                         let diagnostic = new vscode.Diagnostic(range, message, severity);
                         diagnostics.push(diagnostic);
                     }
-                })
+                });
                 this.diagnosticCollection.set(textDocument.uri, diagnostics);
             });
         }
@@ -50,7 +54,7 @@ export default class PuppetLintProvider {
         this.diagnosticCollection = vscode.languages.createDiagnosticCollection();
 
         vscode.workspace.onDidOpenTextDocument(this.doPuppetLint, this, subscriptions);
-        vscode.workspace.onDidCloseTextDocument((textDocument)=> {
+        vscode.workspace.onDidCloseTextDocument((textDocument) => {
             this.diagnosticCollection.delete(textDocument.uri);
         }, null, subscriptions);
 

--- a/src/features/puppetParserProvider.ts
+++ b/src/features/puppetParserProvider.ts
@@ -1,0 +1,78 @@
+"use strict";
+
+import * as cp from "child_process";
+import * as vscode from "vscode";
+
+export default class PuppetParserProvider {
+
+    private diagnosticCollection: vscode.DiagnosticCollection;
+    private command: vscode.Disposable;
+    private regex: RegExp = new RegExp("(\\[\\d{1,};\\d{1,}m)(Error|Warning):\\s(.*)at(.*):(\\d{1,})");
+
+    public activate(subscriptions: vscode.Disposable[]) {
+
+        this.diagnosticCollection = vscode.languages.createDiagnosticCollection("PuppetParser");
+
+        vscode.workspace.onDidOpenTextDocument(this.doPuppetParser, this, subscriptions);
+
+        vscode.workspace.onDidCloseTextDocument((textDocument) => {
+            this.diagnosticCollection.delete(textDocument.uri);
+        }, null, subscriptions);
+
+        vscode.workspace.onDidSaveTextDocument(this.doPuppetParser, this);
+        vscode.workspace.textDocuments.forEach(this.doPuppetParser, this);
+    }
+
+    public dispose(): void {
+        this.diagnosticCollection.clear();
+        this.diagnosticCollection.dispose();
+        this.command.dispose();
+    }
+
+    private doPuppetParser(textDocument: vscode.TextDocument) {
+
+        if (textDocument.languageId !== "puppet") {
+            return;
+        }
+
+        let decoded: string = "";
+        let diagnostics: vscode.Diagnostic[] = [];
+        let options: cp.SpawnOptions = vscode.workspace.rootPath ? { cwd: vscode.workspace.rootPath, shell: true } : undefined;
+
+        const config = vscode.workspace.getConfiguration('puppet');
+
+        let path = config.get<string>('puppet');
+
+        if (path.indexOf(' ') > -1) {
+            path = `"${path}"`;
+        }
+
+        let childProcess: cp.ChildProcess = cp.spawn(path, ["parser", "validate", "\"" + textDocument.fileName + "\""], options);
+
+        if (childProcess.pid) {
+            childProcess.stderr.on("data", (data: Buffer) => {
+                decoded += data;
+            });
+
+            // Puppet Parser Validate uses Standard Error            
+            childProcess.stderr.on("end", () => {
+
+                decoded.split("\n").forEach(item => {
+
+                    if (item) {
+                        var matches: RegExpExecArray = this.regex.exec(item);
+                        let isWarning = matches[2].toLowerCase() === "warning";
+                        let severity = isWarning ? vscode.DiagnosticSeverity.Warning : vscode.DiagnosticSeverity.Error;
+                        let message = "puppet parser validate: " + matches[3];
+                        let range = new vscode.Range(Number(matches[5]) - 1, 0, Number(matches[5]), 300);
+                        let diagnostic = new vscode.Diagnostic(range, message, severity);
+                        diagnostics.push(diagnostic);
+                    }
+
+                });
+
+                this.diagnosticCollection.set(textDocument.uri, diagnostics);
+            });
+        }
+    }
+}

--- a/syntaxes/puppet.tmLanguage.json
+++ b/syntaxes/puppet.tmLanguage.json
@@ -1,0 +1,472 @@
+{
+    "fileTypes": [
+        "pp",
+        "epp"
+    ],
+    "foldingStartMarker": "(^\\s*\/\\*|(\\{|\\[|\\()\\s*$)",
+    "foldingStopMarker": "(\\*\/|^\\s*(\\}|\\]|\\)))",
+    "name": "Puppet",
+    "patterns": [{
+            "include": "#line_comment"
+        },
+        {
+            "include": "#constants"
+        },
+        {
+            "begin": "^\\s*\/\\*",
+            "end": "\\*\/",
+            "name": "comment.block.puppet"
+        },
+        {
+            "begin": "^\\s*(node|class)\\s+((?:[-_A-Za-z0-9\";.]+::)*[-_A-Za-z0-9\";.]+)\\s*",
+            "captures": {
+                "1": {
+                    "name": "storage.type.puppet"
+                },
+                "2": {
+                    "name": "entity.name.type.class.puppet"
+                }
+            },
+            "end": "(?={)",
+            "name": "meta.definition.class.puppet",
+            "patterns": [{
+                    "begin": "\\b(inherits)\\b\\s+",
+                    "captures": {
+                        "1": {
+                            "name": "storage.modifier.puppet"
+                        }
+                    },
+                    "end": "(?={)",
+                    "name": "meta.definition.class.inherits.puppet",
+                    "patterns": [{
+                        "match": "\\b((?:[-_A-Za-z0-9\".]+::)*[-_A-Za-z0-9\".]+)\\b",
+                        "name": "support.type.puppet"
+                    }]
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "variable.other.puppet"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.variable.puppet"
+                        }
+                    },
+                    "match": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))",
+                    "name": "meta.function.argument.no-default.puppet"
+                },
+                {
+                    "begin": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*",
+                    "captures": {
+                        "1": {
+                            "name": "variable.other.puppet"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.variable.puppet"
+                        },
+                        "3": {
+                            "name": "keyword.operator.assignment.puppet"
+                        }
+                    },
+                    "end": "(?=,|\\))",
+                    "name": "meta.function.argument.default.puppet",
+                    "patterns": [{
+                        "include": "#parameter-default-types"
+                    }]
+                }
+            ]
+        },
+        {
+            "begin": "^\\s*(define)\\s+([a-zA-Z0-9_:]+)\\s*(\\()",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.function.puppet"
+                },
+                "2": {
+                    "name": "entity.name.function.puppet"
+                },
+                "3": {
+                    "name": "punctuation.definition.parameters.begin.puppet"
+                }
+            },
+            "contentName": "meta.function.arguments.puppet",
+            "end": "\\)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.parameters.end.puppet"
+                }
+            },
+            "name": "meta.function.puppet",
+            "patterns": [{
+                    "captures": {
+                        "1": {
+                            "name": "variable.other.puppet"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.variable.puppet"
+                        }
+                    },
+                    "match": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)\\s*(?=,|\\))",
+                    "name": "meta.function.argument.no-default.puppet"
+                },
+                {
+                    "begin": "((\\$+)[a-zA-Z_][a-zA-Z0-9_]*)(?:\\s*(=)\\s*)\\s*",
+                    "captures": {
+                        "1": {
+                            "name": "variable.other.puppet"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.variable.puppet"
+                        },
+                        "3": {
+                            "name": "keyword.operator.assignment.puppet"
+                        }
+                    },
+                    "end": "(?=,|\\))",
+                    "name": "meta.function.argument.default.puppet",
+                    "patterns": [{
+                        "include": "#parameter-default-types"
+                    }]
+                }
+            ]
+        },
+        {
+            "captures": {
+                "1": {
+                    "name": "constant.other.key.puppet"
+                },
+                "2": {
+                    "name": "storage.type.puppet"
+                },
+                "3": {
+                    "name": "entity.name.section.puppet"
+                }
+            },
+            "match": "^\\s*(->)?\\s*(\\w+)\\s*{\\s*(['\"].+['\"]):",
+            "name": "meta.definition.resource.puppet"
+        },
+        {
+            "captures": {
+                "1": {
+                    "name": "storage.type.puppet"
+                },
+                "2": {
+                    "name": "entity.name.section.puppet"
+                }
+            },
+            "match": "^\\s*(\\w+)\\s*{\\s*(\\$[a-zA-Z_]+)\\s*:",
+            "name": "meta.definition.resource.puppet"
+        },
+        {
+            "match": "\\b(case|if|else|elsif)(?!::)\\b",
+            "name": "keyword.control.puppet"
+        },
+        {
+            "include": "#strings"
+        },
+        {
+            "match": "((\\$?)\"?[a-zA-Z_\\x{7f}-\\x{ff}][a-zA-Z0-9_\\x{7f}-\\x{ff}]*\"?):(?=\\s+|$)",
+            "name": "entity.name.section.puppet"
+        },
+        {
+            "include": "#variable"
+        },
+        {
+            "begin": "\\b(import|include|contain|require)\\s+(?!.*=>)",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.control.import.include.puppet"
+                }
+            },
+            "end": "(?=\\s|$)",
+            "name": "meta.include.puppet"
+        },
+        {
+            "match": "\\b\\w+\\s*(?==>)\\s*",
+            "name": "constant.other.key.puppet"
+        },
+        {
+            "match": "(?<={)\\s*\\w+\\s*(?=})",
+            "name": "constant.other.bareword.puppet"
+        },
+        {
+            "match": "\\b(alert|crit|debug|defined|emerg|err|escape|fail|failed|file|generate|gsub|info|notice|package|realize|search|tag|tagged|template|warning)\\b(?!.*{)",
+            "name": "support.function.puppet"
+        },
+        {
+            "match": "=>",
+            "name": "punctuation.separator.key-value.puppet"
+        }
+    ],
+    "repository": {
+        "array": {
+            "begin": "(\\[)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.array.begin.puppet"
+                }
+            },
+            "end": "\\]",
+            "endCaptures": [{
+                "name": "punctuation.definition.array.end.puppet"
+            }],
+            "name": "meta.array.puppet",
+            "patterns": [{
+                "include": "#parameter-default-types"
+            }]
+        },
+        "constants": {
+            "patterns": [{
+                "match": "\\b(absent|directory|false|undef|file|present|running|stopped|true)\\b(?!.*{)",
+                "name": "constant.language.puppet"
+            }]
+        },
+        "double-quoted-string": {
+            "begin": "\"",
+            "beginCaptures": [{
+                "name": "punctuation.definition.string.begin.puppet"
+            }],
+            "end": "\"",
+            "endCaptures": [{
+                "name": "punctuation.definition.string.end.puppet"
+            }],
+            "name": "string.quoted.double.puppet",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#variable"
+                }
+            ]
+        },
+        "escaped_char": {
+            "match": "\\\\.",
+            "name": "constant.character.escape.puppet"
+        },
+        "hash": {
+            "begin": "\\{",
+            "beginCaptures": [{
+                "name": "punctuation.definition.hash.begin.puppet"
+            }],
+            "end": "\\}",
+            "endCaptures": [{
+                "name": "punctuation.definition.hash.end.puppet"
+            }],
+            "name": "meta.hash.puppet",
+            "patterns": [{
+                    "match": "\\b\\w+\\s*(?==>)\\s*",
+                    "name": "constant.other.key.puppet"
+                },
+                {
+                    "include": "#parameter-default-types"
+                }
+            ]
+        },
+        "line_comment": {
+            "patterns": [{
+                    "captures": {
+                        "1": {
+                            "name": "comment.line.number-sign.puppet"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.comment.puppet"
+                        }
+                    },
+                    "match": "^((#).*$\\n?)",
+                    "name": "meta.comment.full-line.puppet"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.comment.puppet"
+                        }
+                    },
+                    "match": "(#).*$\\n?",
+                    "name": "comment.line.number-sign.puppet"
+                }
+            ]
+        },
+        "nested_braces": {
+            "begin": "\\{",
+            "captures": {
+                "1": {
+                    "name": "punctuation.section.scope.puppet"
+                }
+            },
+            "end": "\\}",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#nested_braces"
+                }
+            ]
+        },
+        "nested_braces_interpolated": {
+            "begin": "\\{",
+            "captures": {
+                "1": {
+                    "name": "punctuation.section.scope.puppet"
+                }
+            },
+            "end": "\\}",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#variable"
+                },
+                {
+                    "include": "#nested_braces_interpolated"
+                }
+            ]
+        },
+        "nested_brackets": {
+            "begin": "\\[",
+            "captures": {
+                "1": {
+                    "name": "punctuation.section.scope.puppet"
+                }
+            },
+            "end": "\\]",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#nested_brackets"
+                }
+            ]
+        },
+        "nested_brackets_interpolated": {
+            "begin": "\\[",
+            "captures": {
+                "1": {
+                    "name": "punctuation.section.scope.puppet"
+                }
+            },
+            "end": "\\]",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#variable"
+                },
+                {
+                    "include": "#nested_brackets_interpolated"
+                }
+            ]
+        },
+        "nested_parens": {
+            "begin": "\\(",
+            "captures": {
+                "1": {
+                    "name": "punctuation.section.scope.puppet"
+                }
+            },
+            "end": "\\)",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#nested_parens"
+                }
+            ]
+        },
+        "nested_parens_interpolated": {
+            "begin": "\\(",
+            "captures": {
+                "1": {
+                    "name": "punctuation.section.scope.puppet"
+                }
+            },
+            "end": "\\)",
+            "patterns": [{
+                    "include": "#escaped_char"
+                },
+                {
+                    "include": "#variable"
+                },
+                {
+                    "include": "#nested_parens_interpolated"
+                }
+            ]
+        },
+        "parameter-default-types": {
+            "patterns": [{
+                    "include": "#strings"
+                },
+                {
+                    "include": "#numbers"
+                },
+                {
+                    "include": "#variables"
+                },
+                {
+                    "include": "#hash"
+                },
+                {
+                    "include": "#array"
+                },
+                {
+                    "begin": "([a-zA-Z_][a-zA-Z0-9_]*)(\\()",
+                    "end": "(\\))",
+                    "name": "meta.function.puppet",
+                    "patterns": [{
+                        "include": "#parameter-default-types"
+                    }]
+                },
+                {
+                    "include": "#constants"
+                }
+            ]
+        },
+        "single-quoted-string": {
+            "begin": "'",
+            "beginCaptures": [{
+                "name": "punctuation.definition.string.begin.puppet"
+            }],
+            "end": "'",
+            "endCaptures": [{
+                "name": "punctuation.definition.string.end.puppet"
+            }],
+            "name": "string.quoted.single.puppet",
+            "patterns": [{
+                "include": "#escaped_char"
+            }]
+        },
+        "strings": {
+            "patterns": [{
+                    "include": "#double-quoted-string"
+                },
+                {
+                    "include": "#single-quoted-string"
+                }
+            ]
+        },
+        "variable": {
+            "patterns": [{
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.variable.puppet"
+                        }
+                    },
+                    "match": "(\\$)((::)?[a-z]\\w*)*((::)?[a-z_]\\w*)\\b",
+                    "name": "variable.other.readwrite.global.puppet"
+                },
+                {
+                    "captures": {
+                        "1": {
+                            "name": "punctuation.definition.variable.puppet"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.variable.puppet"
+                        }
+                    },
+                    "match": "(\\$\\{)(?:[a-zA-Zx7f-xff\\$]|::)(?:[a-zA-Z0-9_x7f-xff\\$]|::)*(\\})",
+                    "name": "variable.other.readwrite.global.puppet"
+                }
+            ]
+        }
+    },
+    "scopeName": "source.puppet"
+}

--- a/tslint.json
+++ b/tslint.json
@@ -1,0 +1,15 @@
+{
+    "rules": {
+        "no-unused-expression": true,
+        "no-duplicate-variable": true,
+        "no-duplicate-key": true,
+        "no-unused-variable": true,
+        "curly": true,
+        "class-name": true,
+        "semicolon": ["always"],
+        "triple-equals": true,
+        "quotemark": [
+            "single"
+        ]
+    }
+}


### PR DESCRIPTION
- Settings for location of parser and puppet exe/bat files
- If path contains spaces, wrap it in '"' for cp.spawn
- converted tmLanguage to tmLanguage.json for easier navigation
- Added -> syntax support because i was losing some syntax highlighting
- There still seems to be a minor syntax highlight problem when using a defined resource.